### PR TITLE
Refactor save loading into saveManager

### DIFF
--- a/modules/save/saveManager.js
+++ b/modules/save/saveManager.js
@@ -1,5 +1,7 @@
 // 게임 상태를 저장하고 불러오는 기능을 제공한다.
-import { getCurrentTheme } from '../ui/themeManager.js';
+import { getCurrentTheme, applyTheme } from '../ui/themeManager.js';
+import { showAnswerInput, initHintSystem } from '../dialogue/answerHandler.js';
+import { autoUpdateSkipButton } from '../ui/control/skipButtonController.js';
 
 export function buildSaveData(context) {
   let lastImage = null, lastImageIndex = -1;
@@ -57,4 +59,107 @@ export function downloadSave(slotNumber, context, showPopupFn) {
   if (typeof showPopupFn === 'function') {
     showPopupFn(`슬롯 ${slotNumber}에 파일로 저장되었습니다.`);
   }
+}
+
+export function loadSaveData(context, data) {
+  if (data.theme) applyTheme(data.theme);
+  context.currentDialogue = data.dialogue;
+  context.indexRef.value = data.index;
+  context.saveLoaded = true;
+  context.isRestored = true;
+
+  const videoEl = document.getElementById('bg-video');
+  if (data.lastVideoIndex > data.lastImageIndex) {
+    if (videoEl) {
+      videoEl.src = data.lastVideo;
+      videoEl.load();
+      videoEl.style.display = 'block';
+    }
+    if (context.gameWrapper) context.gameWrapper.style.background = '';
+    const startScreen = document.getElementById('main-start-screen');
+    if (startScreen) startScreen.style.background = '';
+    if (context.overlayImage) {
+      context.overlayImage.style.display = 'none';
+      context.overlayImage.src = '';
+    }
+  } else {
+    if (context.gameWrapper) {
+      context.gameWrapper.style.background = `url('${data.lastImage}') no-repeat center center`;
+      context.gameWrapper.style.backgroundSize = 'cover';
+    }
+    if (videoEl) videoEl.style.display = 'none';
+  }
+
+  if (data.overlayImageSrc) {
+    context.overlayImage.src = data.overlayImageSrc;
+    context.overlayImage.style.display = data.overlayImageVisible;
+  }
+
+  if (data.overlayHistory !== undefined && context.kakaoOverlay) {
+    context.kakaoOverlay.innerHTML = data.overlayHistory;
+  }
+
+  if (data.history !== undefined) {
+    context.kakaoBox.innerHTML = data.history;
+    const current = context.currentDialogue[context.indexRef.value];
+    if (current.notification) {
+      if (current.hideKakao) {
+        context.kakaoBox.style.display = 'none';
+        context.kakaoOverlay.style.display = 'none';
+      } else {
+        context.kakaoBox.style.display = 'block';
+        context.kakaoOverlay.style.display = 'block';
+        context.scrollToBottom(context.kakaoBox);
+      }
+    }
+    if (!current.notification) {
+      context.kakaoBox.style.display = 'block';
+      context.kakaoOverlay.style.display = 'block';
+      context.scrollToBottom(context.kakaoBox);
+    }
+  }
+
+  if (data.choiceHistory !== undefined) {
+    context.choiceContainer.innerHTML = data.choiceHistory;
+    context.choiceContainer.style.display = data.choiceVisible;
+    autoUpdateSkipButton(context);
+  }
+
+  if (data.answerVisible && data.answerVisible !== 'none') {
+    context.answerContainer.innerHTML = data.answerHTML;
+    context.answerContainer.style.display = data.answerVisible;
+    const correct = context.currentDialogue[context.indexRef.value].answer;
+    showAnswerInput(correct, context);
+    context.isWaitingForAnswer.value = true;
+    context.suppressClick = true;
+    context.toggleKakaoDisplay(false, context.kakaoBox, context.kakaoOverlay);
+  }
+
+  if (context.currentDialogue[context.indexRef.value].answer) {
+    context.toggleKakaoDisplay(false, context.kakaoBox, context.kakaoOverlay);
+  }
+
+  const first = context.currentDialogue[context.indexRef.value];
+  if (first && first.talk) {
+    context.talkWrapper.style.display = 'block';
+    context.nameEl.textContent = first.name || '';
+    context.bubbleEl.textContent = first.text || '';
+  }
+  if (context.currentDialogue[context.indexRef.value].hideKakao) {
+    context.toggleKakaoDisplay(false, context.kakaoBox, context.kakaoOverlay);
+  }
+
+  const intro = document.getElementById('intro-screen');
+  if (intro) intro.remove();
+  document.getElementById('main-start-screen').style.display = 'flex';
+  document.getElementById('game-wrapper').style.display = 'none';
+  context.updateLevelBar(context.indexRef.value, context.currentDialogue);
+  context.notificationActive = false;
+  autoUpdateSkipButton(context);
+  context.overlayJustCleared = false;
+  setTimeout(() => {
+    context.suppressClick = false;
+  }, 300);
+  context.preventAutoAdvance.value = false;
+  initHintSystem(context);
 }

--- a/modules/ui/popup/startChoicePopup.js
+++ b/modules/ui/popup/startChoicePopup.js
@@ -1,6 +1,6 @@
-import { initHintSystem, showAnswerInput } from '../../dialogue/answerHandler.js';
-import { applyTheme } from '../themeManager.js';
+import { initHintSystem } from '../../dialogue/answerHandler.js';
 import { autoUpdateSkipButton } from '../control/skipButtonController.js';
+import { loadSaveData } from '../../save/saveManager.js';
 
 export function setupStartChoicePopup(context, currentDialogue) {
   const startChoicePopup = document.createElement('div');
@@ -67,109 +67,6 @@ export function setupStartChoicePopup(context, currentDialogue) {
     autoUpdateSkipButton(context);
   };
 
-  const handleLoadData = (data) => {
-    if (data.theme) applyTheme(data.theme);
-    context.currentDialogue = data.dialogue;
-    context.indexRef.value = data.index;
-    context.saveLoaded = true;
-    context.isRestored = true;
-
-    const videoEl = document.getElementById('bg-video');
-    if (data.lastVideoIndex > data.lastImageIndex) {
-      if (videoEl) {
-        videoEl.src = data.lastVideo;
-        videoEl.load();
-        videoEl.style.display = 'block';
-      }
-      if (context.gameWrapper) context.gameWrapper.style.background = '';
-      const startScreen = document.getElementById('main-start-screen');
-      if (startScreen) startScreen.style.background = '';
-      if (context.overlayImage) {
-        context.overlayImage.style.display = 'none';
-        context.overlayImage.src = '';
-      }
-    } else {
-      if (context.gameWrapper) {
-        context.gameWrapper.style.background = `url('${data.lastImage}') no-repeat center center`;
-        context.gameWrapper.style.backgroundSize = 'cover';
-      }
-      if (videoEl) videoEl.style.display = 'none';
-    }
-
-    if (data.overlayImageSrc) {
-      context.overlayImage.src = data.overlayImageSrc;
-      context.overlayImage.style.display = data.overlayImageVisible;
-    }
-
-    if (data.overlayHistory !== undefined && context.kakaoOverlay) {
-      context.kakaoOverlay.innerHTML = data.overlayHistory;
-    }
-
-    if (data.history !== undefined) {
-      context.kakaoBox.innerHTML = data.history;
-      const current = context.currentDialogue[context.indexRef.value];
-      if (current.notification) {
-        if (current.hideKakao) {
-          context.kakaoBox.style.display = 'none';
-          context.kakaoOverlay.style.display = 'none';
-        } else {
-          context.kakaoBox.style.display = 'block';
-          context.kakaoOverlay.style.display = 'block';
-          context.scrollToBottom(context.kakaoBox);
-        }
-      }
-      if (!current.notification) {
-        context.kakaoBox.style.display = 'block';
-        context.kakaoOverlay.style.display = 'block';
-        context.scrollToBottom(context.kakaoBox);
-      }
-    }
-
-    if (data.choiceHistory !== undefined) {
-      context.choiceContainer.innerHTML = data.choiceHistory;
-      context.choiceContainer.style.display = data.choiceVisible;
-      autoUpdateSkipButton(context);
-    }
-
-    if (data.answerVisible && data.answerVisible !== 'none') {
-      context.answerContainer.innerHTML = data.answerHTML;
-      context.answerContainer.style.display = data.answerVisible;
-      const correct = context.currentDialogue[context.indexRef.value].answer;
-      showAnswerInput(correct, context);
-      context.isWaitingForAnswer.value = true;
-      context.suppressClick = true;
-      context.toggleKakaoDisplay(false, context.kakaoBox, context.kakaoOverlay);
-    }
-
-    if (context.currentDialogue[context.indexRef.value].answer) {
-      context.toggleKakaoDisplay(false, context.kakaoBox, context.kakaoOverlay);
-    }
-
-    const first = context.currentDialogue[context.indexRef.value];
-    if (first && first.talk) {
-      context.talkWrapper.style.display = 'block';
-      context.nameEl.textContent = first.name || '';
-      context.bubbleEl.textContent = first.text || '';
-    }
-    if (context.currentDialogue[context.indexRef.value].hideKakao) {
-      context.toggleKakaoDisplay(false, context.kakaoBox, context.kakaoOverlay);
-    }
-
-    hidePopup();
-    const intro = document.getElementById('intro-screen');
-    if (intro) intro.remove();
-    document.getElementById('main-start-screen').style.display = 'flex';
-    document.getElementById('game-wrapper').style.display = 'none';
-    context.updateLevelBar(context.indexRef.value, context.currentDialogue);
-    context.notificationActive = false;
-    autoUpdateSkipButton(context);
-    context.overlayJustCleared = false;
-    setTimeout(() => {
-      context.suppressClick = false;
-    }, 300);
-    context.preventAutoAdvance.value = false;
-    initHintSystem(context);
-  };
 
   ['1', '2', '3'].forEach((num) => {
     startChoicePopup.querySelector(`#slot-${num}`).onclick = () => {
@@ -188,7 +85,7 @@ export function setupStartChoicePopup(context, currentDialogue) {
               alert('유효하지 않은 저장 파일입니다.');
               return;
             }
-            handleLoadData(data);
+            loadSaveData(context, data);
           } catch (err) {
             console.error('파일 파싱 실패:', err);
             alert('파일 읽기 실패');


### PR DESCRIPTION
## Summary
- centralize save restoration logic in `loadSaveData` function
- call `loadSaveData` from start menu popup when a save file is chosen

## Testing
- `npm test` *(fails: could not find `package.json`)*
- `node -e "require('./modules/save/saveManager.js')"`

------
https://chatgpt.com/codex/tasks/task_e_6847c6717190832bb8ddbefb2bfa29fe