### PR TITLE
Add Jest setup

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,0 +1,20 @@
+# Project Setup
+
+This project uses [Jest](https://jestjs.io/) for testing. The configuration is defined in `jest.config.js` and uses the `jsdom` test environment.
+
+## Running Tests
+
+Install dependencies and run the test suite:
+
+```bash
+npm install
+npm test
+```
+
+The test script runs Jest through Node's experimental VM modules:
+
+```bash
+node --experimental-vm-modules node_modules/.bin/jest
+```
+
+

--- a/jest.config.js
+++ b/jest.config.js
@@ -1,0 +1,3 @@
+module.exports = {
+  testEnvironment: "jsdom",
+};

--- a/package.json
+++ b/package.json
@@ -1,0 +1,10 @@
+{
+  "name": "project",
+  "type": "module",
+  "scripts": {
+    "test": "node --experimental-vm-modules node_modules/.bin/jest"
+  },
+  "devDependencies": {
+    "jest": "^29.0.0"
+  }
+}


### PR DESCRIPTION
## Summary
- add Jest config using jsdom
- add test script to `package.json`
- document testing instructions in README

## Testing
- `npm test` *(fails: Cannot find module '/workspace/.610/node_modules/.bin/jest')*

------
https://chatgpt.com/codex/tasks/task_e_6848d7aba608832b92bf2c27c85cf8b0