### PR TITLE
Use context.suppressClick for click suppression

### DIFF
--- a/modules/dialogue/choiceHandler.js
+++ b/modules/dialogue/choiceHandler.js
@@ -28,7 +28,7 @@ export function attachChoiceListener(container, context, showDialogue) {
     if (!btn) return;
 
     e.stopPropagation();
-    window.suppressClick = true;
+    context.suppressClick = true;
 
     let branch;
     try {
@@ -77,7 +77,7 @@ export function attachChoiceListener(container, context, showDialogue) {
       context.kakaoBox.style.display = 'block';
       context.kakaoOverlay.style.display = 'block';
       showDialogue(idx, context);
-      window.suppressClick = false;
+      context.suppressClick = false;
     }, 600);
   });
 }

--- a/modules/ui/popup/savePopupManager.js
+++ b/modules/ui/popup/savePopupManager.js
@@ -33,7 +33,7 @@ export function setupSavePopup(context) {
   msgBox.querySelector('.popup-message-close').addEventListener('click', (e) => {
     e.stopPropagation();
     msgBox.classList.remove('active');
-    window.suppressClick = false;
+    context.suppressClick = false;
   });
 
   context.saveBtn.onclick = (e) => {
@@ -58,7 +58,7 @@ export function setupSavePopup(context) {
       e.stopPropagation();
       savePopup.style.display = 'none';
       setTimeout(() => {
-        window.suppressClick = false;
+        context.suppressClick = false;
       }, 300);
     };
   }


### PR DESCRIPTION
## Summary
- use `context.suppressClick` instead of global `window.suppressClick`
- update popup and choice handlers to reference the shared context state

## Testing
- `grep -R "window.suppressClick" -n`

------
https://chatgpt.com/codex/tasks/task_e_6848daefb374832ba5c7ad6a7b9450d6