### PR TITLE
Reset attendance on new game

### DIFF
--- a/README.md
+++ b/README.md
@@ -23,6 +23,8 @@ This script uses Node's `http` module to serve the project locally without any e
 
 Daily attendance grants in-game "복" points. Progress and your current 복 count are stored in `localStorage` and included when saving and loading game data.
 
+Starting a new game now clears these stored values so attendance rewards and bok points reset.
+
 ## Running Tests
 
 This project includes a small Node-based test suite. Run it with:

--- a/index.html
+++ b/index.html
@@ -69,6 +69,9 @@
 <!-- 출석 보상 오버레이 -->
 <div id="attendance-reward" class="hidden">
   <div class="reward-box">
+    <div id="reward-overlay-close" class="reward-popup-close">
+      <img src="images/close-icon.png" alt="닫기">
+    </div>
     <div class="reward-title">미션 완료!</div>
     <img src="images/bok-bag.png" class="reward-img" alt="복주머니">
     <div id="reward-text" class="reward-text">복 5개를 받았어요!</div>

--- a/index.html
+++ b/index.html
@@ -67,16 +67,11 @@
 </div>
 
 <!-- 출석 보상 오버레이 -->
-<div id="attendance-reward" class="hidden">
-  <div class="reward-box">
-    <div id="reward-overlay-close" class="reward-popup-close">
-      <img src="images/close-icon.png" alt="닫기">
-    </div>
-    <div class="reward-title">미션 완료!</div>
-    <img src="images/bok-bag.png" class="reward-img" alt="복주머니">
-    <div id="reward-text" class="reward-text">복 5개를 받았어요!</div>
-    <button id="reward-close" class="reward-close">확인</button>
-  </div>
+<div id="attendance-reward" class="hidden reward-box">
+  <div class="reward-title">미션 완료!</div>
+  <img src="images/bok-bag.png" class="reward-img" alt="복주머니">
+  <div id="reward-text" class="reward-text">복 5개를 받았어요!</div>
+  <button id="reward-close" class="reward-close">확인</button>
 </div>
 
 <!-- ✅ 메인 스크립트 실행 -->

--- a/modules/ui/introScreenManager.js
+++ b/modules/ui/introScreenManager.js
@@ -230,7 +230,9 @@ export function createIntroScreen(startGameCallback, showDialogue, context) {
         }
         if (countNow >= rewardArr.length) confirmBtn.disabled = true;
         hideBottomSheet();
-        showReward(earned);
+        setTimeout(() => {
+          showReward(earned);
+        }, 300);
       };
     }
 

--- a/modules/ui/introScreenManager.js
+++ b/modules/ui/introScreenManager.js
@@ -118,29 +118,22 @@ export function createIntroScreen(startGameCallback, showDialogue, context) {
   let rewardOverlay = document.getElementById('attendance-reward');
   let rewardText = document.getElementById('reward-text');
   let rewardClose = document.getElementById('reward-close');
-  let rewardOverlayClose = document.getElementById('reward-overlay-close');
 
   function ensureRewardOverlay() {
     if (!rewardOverlay) {
       rewardOverlay = document.createElement('div');
       rewardOverlay.id = 'attendance-reward';
-      rewardOverlay.className = 'hidden';
+      rewardOverlay.className = 'hidden reward-box';
       rewardOverlay.innerHTML = `
-        <div class="reward-box">
-          <div id="reward-overlay-close" class="reward-popup-close">
-            <img src="images/close-icon.png" alt="닫기">
-          </div>
-          <div class="reward-title">미션 완료!</div>
-          <img src="images/bok-bag.png" class="reward-img" alt="복주머니">
-          <div id="reward-text" class="reward-text"></div>
-          <button id="reward-close" class="reward-close">확인</button>
-        </div>`;
+        <div class="reward-title">미션 완료!</div>
+        <img src="images/bok-bag.png" class="reward-img" alt="복주머니">
+        <div id="reward-text" class="reward-text"></div>
+        <button id="reward-close" class="reward-close">확인</button>`;
       document.body.appendChild(rewardOverlay);
     }
 
     rewardText = rewardOverlay.querySelector('#reward-text');
     rewardClose = rewardOverlay.querySelector('#reward-close');
-    rewardOverlayClose = rewardOverlay.querySelector('#reward-overlay-close');
 
     rewardOverlay.addEventListener('click', (e) => {
       if (e.target === rewardOverlay) hideReward();
@@ -148,12 +141,6 @@ export function createIntroScreen(startGameCallback, showDialogue, context) {
 
     if (rewardClose) {
       rewardClose.onclick = (e) => {
-        e.stopPropagation();
-        hideReward();
-      };
-    }
-    if (rewardOverlayClose) {
-      rewardOverlayClose.onclick = (e) => {
         e.stopPropagation();
         hideReward();
       };

--- a/modules/ui/introScreenManager.js
+++ b/modules/ui/introScreenManager.js
@@ -118,6 +118,7 @@ export function createIntroScreen(startGameCallback, showDialogue, context) {
   let rewardOverlay = document.getElementById('attendance-reward');
   let rewardText = document.getElementById('reward-text');
   let rewardClose = document.getElementById('reward-close');
+  let rewardOverlayClose = document.getElementById('reward-overlay-close');
 
   function ensureRewardOverlay() {
     if (!rewardOverlay) {
@@ -126,6 +127,9 @@ export function createIntroScreen(startGameCallback, showDialogue, context) {
       rewardOverlay.className = 'hidden';
       rewardOverlay.innerHTML = `
         <div class="reward-box">
+          <div id="reward-overlay-close" class="reward-popup-close">
+            <img src="images/close-icon.png" alt="닫기">
+          </div>
           <div class="reward-title">미션 완료!</div>
           <img src="images/bok-bag.png" class="reward-img" alt="복주머니">
           <div id="reward-text" class="reward-text"></div>
@@ -136,6 +140,7 @@ export function createIntroScreen(startGameCallback, showDialogue, context) {
 
     rewardText = rewardOverlay.querySelector('#reward-text');
     rewardClose = rewardOverlay.querySelector('#reward-close');
+    rewardOverlayClose = rewardOverlay.querySelector('#reward-overlay-close');
 
     rewardOverlay.addEventListener('click', (e) => {
       if (e.target === rewardOverlay) hideReward();
@@ -143,6 +148,12 @@ export function createIntroScreen(startGameCallback, showDialogue, context) {
 
     if (rewardClose) {
       rewardClose.onclick = (e) => {
+        e.stopPropagation();
+        hideReward();
+      };
+    }
+    if (rewardOverlayClose) {
+      rewardOverlayClose.onclick = (e) => {
         e.stopPropagation();
         hideReward();
       };

--- a/modules/ui/introScreenManager.js
+++ b/modules/ui/introScreenManager.js
@@ -230,9 +230,7 @@ export function createIntroScreen(startGameCallback, showDialogue, context) {
         }
         if (countNow >= rewardArr.length) confirmBtn.disabled = true;
         hideBottomSheet();
-        setTimeout(() => {
-          showReward(earned);
-        }, 300);
+        showReward(earned);
       };
     }
 

--- a/modules/ui/popup/startChoicePopup.js
+++ b/modules/ui/popup/startChoicePopup.js
@@ -69,6 +69,12 @@ export function setupStartChoicePopup(context, currentDialogue) {
     hidePopup();
     document.getElementById('main-start-screen').style.display = 'none';
     document.getElementById('game-wrapper').style.display = 'block';
+    // Reset persistent data so a new game truly starts fresh
+    localStorage.removeItem('attendanceCount');
+    context.attendanceCount = 0;
+    localStorage.removeItem('bokCount');
+    context.bokCount = 0;
+    context.updateBokDisplay(context.bokCount);
     context.gameStarted = true;
     if (context.menuBtn) context.menuBtn.style.display = 'block';
     context.indexRef.value = 0;

--- a/style.css
+++ b/style.css
@@ -1445,6 +1445,7 @@ body.dark-mode {
   padding: 20px;
   text-align: center;
   width: 260px;
+  position: relative;
 }
 
 .reward-title {
@@ -1471,5 +1472,17 @@ body.dark-mode {
   background: #4caf50;
   color: white;
   cursor: pointer;
+}
+
+.reward-popup-close {
+  position: absolute;
+  top: 12px;
+  right: 12px;
+  cursor: pointer;
+}
+
+.reward-popup-close img {
+  width: 20px;
+  height: auto;
 }
 

--- a/style.css
+++ b/style.css
@@ -1474,15 +1474,4 @@ body.dark-mode {
   cursor: pointer;
 }
 
-.reward-popup-close {
-  position: absolute;
-  top: 12px;
-  right: 12px;
-  cursor: pointer;
-}
-
-.reward-popup-close img {
-  width: 20px;
-  height: auto;
-}
 


### PR DESCRIPTION
## Summary
- reset `attendanceCount` and `bokCount` in local storage when starting a new game
- update README to mention that starting over clears attendance progress

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_684bcff7fa14832b8e0ba082e462c6ba